### PR TITLE
netlink: Check MAX_PAYLOAD in meth_send as well

### DIFF
--- a/src/netlink.c
+++ b/src/netlink.c
@@ -95,6 +95,12 @@ static int meth_send(lua_State *L) {
     size_t sent = 0;
     int err;
 
+    if (payload_size > NLMSG_ALIGN(MAX_PAYLOAD)) {
+        lua_pushnil(L);
+        lua_pushliteral(L, "payload too big");
+        return 2;
+    }
+
     nlb.hdr = (struct nlmsghdr) {
         .nlmsg_len = NLMSG_LENGTH(payload_size),
         .nlmsg_pid = nl->srcpid,


### PR DESCRIPTION
Originally this pre-dated 40a96dd979523bd0bf650a084e320ad1494a7a6a and performed (essentially) the same change, now this is rebased to only provide some consistency.

----

For consistency with meth_sendto. Otherwise the memcpy a few lines could
overrun and cause problems.